### PR TITLE
Fix for cron backup upload to cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,16 @@ The following environment variables may be set when starting the container:
 |--------------------------|----------------------------------------------------------------------------------|
 | /home/barman/.ssh/id_rsa | The private ssh key that barman will use to connect to remote host when recovery |
 
+
+## Azure Storage
+
+Barman supports cloud backup and current projects supports uploading backups to azure storage account.
+
+## Change log
+
+* 3.5.0 - Initial Barman
+* 3.5.1 - Fix to push backups taken from cronjob to azure storage.
+
 ## Footnotes:
 
 <a name='barman_docs'><sup>1</sup></a>: [Barman Documentation](http://docs.pgbarman.org/release/2.1/)

--- a/barman.conf.template
+++ b/barman.conf.template
@@ -42,7 +42,7 @@ compression = gzip
 ;pre_backup_script = env | grep ^BARMAN
 ;pre_backup_retry_script = env | grep ^BARMAN
 ;post_backup_retry_script = env | grep ^BARMAN
-post_backup_script = 'barman-cloud-backup --cloud-provider azure-blob-storage https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${DB_CONF_SERVER_NAME}  ${DB_CONF_SERVER_NAME}'
+post_backup_script = '/usr/local/bin/barman-cloud-backup --cloud-provider azure-blob-storage https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${DB_CONF_SERVER_NAME}  ${DB_CONF_SERVER_NAME}'
 
 ; Pre/post archive hook scripts
 ;pre_archive_script = env | grep ^BARMAN

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   barman:
-    image: quay.io/rapyuta/barman:3.5.0
+    image: quay.io/rapyuta/barman:3.5.1
     build:
       context: .
     network_mode: host

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ install -d -m 0755 -o barman -g barman ${BARMAN_LOG_DIR}
 
 echo "Generating cron schedules"
 echo "${BARMAN_CRON_SCHEDULE} barman /usr/local/bin/barman receive-wal --create-slot ${DB_CONF_SERVER_NAME}; /usr/local/bin/barman cron 2>&1 >> ${BARMAN_LOG_DIR}/barman-cron.log" >> /etc/cron.d/barman
-echo "${BARMAN_BACKUP_SCHEDULE} barman /usr/local/bin/barman backup --wait --jobs 4 all 2>&1 >> ${BARMAN_LOG_DIR}/barman-cron.log" >> /etc/cron.d/barman
+echo "${BARMAN_BACKUP_SCHEDULE} barman export AZURE_STORAGE_KEY=${AZURE_STORAGE_KEY} AZURE_STORAGE_ACCOUNT=${AZURE_STORAGE_ACCOUNT}; /usr/local/bin/barman backup --wait --jobs 4 all 2>&1 >> ${BARMAN_LOG_DIR}/barman-cron.log" >> /etc/cron.d/barman
 
 echo "Generating Barman configurations"
 cat /etc/barman.conf.template | envsubst > /etc/barman.conf


### PR DESCRIPTION
wrike : https://www.wrike.com/open.htm?id=1126753753

short description:
  Any command/script executed through cron will not have access user environment variables or variables passed through rapyuta.io.
  To solve this we need to pass the variables to cron explicitly.